### PR TITLE
Fixed crash with pubYear

### DIFF
--- a/Pod/Classes/RFAboutView.swift
+++ b/Pod/Classes/RFAboutView.swift
@@ -162,6 +162,7 @@ public class RFAboutViewController: UIViewController,UITableViewDataSource,UITab
         self.websiteURLTitle = websiteURLTitle;
         self.copyrightHolderName = copyrightHolderName;
         self.websiteURL = websiteURL;
+        self.pubYear = pubYear
         
         if appName == nil {
             self.appName = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleName") as! String!

--- a/Pod/Classes/RFAboutView.swift
+++ b/Pod/Classes/RFAboutView.swift
@@ -154,14 +154,14 @@ public class RFAboutViewController: UIViewController,UITableViewDataSource,UITab
         self.navigationBarBarTintColor = self.navigationController?.navigationBar.barTintColor // Set from system default
         self.navigationBarTintColor = self.tintColor // Set from system default
         
-        self.appName = appName;
-        self.appVersion = appVersion;
-        self.appBuild = appBuild;
-        self.contactEmail = contactEmail;
-        self.contactEmailTitle = contactEmailTitle;
-        self.websiteURLTitle = websiteURLTitle;
-        self.copyrightHolderName = copyrightHolderName;
-        self.websiteURL = websiteURL;
+        self.appName = appName
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.contactEmail = contactEmail
+        self.contactEmailTitle = contactEmailTitle
+        self.websiteURLTitle = websiteURLTitle
+        self.copyrightHolderName = copyrightHolderName
+        self.websiteURL = websiteURL
         self.pubYear = pubYear
         
         if appName == nil {
@@ -652,7 +652,7 @@ public class RFAboutViewController: UIViewController,UITableViewDataSource,UITab
                 outputArray.addObject(["title":tempTile,"content":tempContent])
             }
         }
-        return outputArray;
+        return outputArray
     }
     
     //MARK:- Autorotation


### PR DESCRIPTION
Thanks for providing a great library. I'll use it next my app.
But RFAboutViewController is crashed when specifying `pubYear` with `fatal error: unexpectedly found nil while unwrapping an Optional value`.
I fixed it and remove semicolons.
